### PR TITLE
Add cubic-dev-ai[bot] to code review benchmark

### DIFF
--- a/online/etl/config.py
+++ b/online/etl/config.py
@@ -72,6 +72,7 @@ DEFAULT_CHATBOT_USERNAMES = [
     "claude[bot]",
     "coderabbitai[bot]",
     "Copilot",
+    "cubic-dev-ai[bot]",
     "cursor[bot]",
     "entelligence-ai-pr-reviews[bot]",
     "factory-droid[bot]",


### PR DESCRIPTION
# Add cubic-dev-ai[bot] to code review benchmark

## Summary
Adds `cubic-dev-ai[bot]` to the `DEFAULT_CHATBOT_USERNAMES` list in `online/etl/config.py`, maintaining alphabetical order. This enables the ETL pipeline to discover and analyze Cubic's code review activity from BigQuery alongside the other tracked bots.

## Review & Testing Checklist for Human
- [ ] Verify `cubic-dev-ai[bot]` is the correct GitHub username for the Cubic bot (app id: 191113872)

### Notes
- Verified bot user via GitHub API: https://github.com/apps/cubic-dev-ai
