### PR TITLE
Add minimum sample size filter

### DIFF
--- a/online/api_service/src/compute.rs
+++ b/online/api_service/src/compute.rs
@@ -321,8 +321,25 @@ pub fn daily_metrics(snapshot: &Snapshot, params: &FilterParams) -> DailyMetrics
         }
     }
 
+    // If min_scored_prs is set, compute total scored per bot and build exclusion set
+    let excluded_bots: HashSet<u8> = if params.min_scored_prs > 0 {
+        let mut totals: HashMap<u8, usize> = HashMap::new();
+        for ((_, idx), acc) in &buckets {
+            *totals.entry(*idx).or_default() += acc.precision_count;
+        }
+        totals.into_iter()
+            .filter(|(_, count)| *count < params.min_scored_prs)
+            .map(|(idx, _)| idx)
+            .collect()
+    } else {
+        HashSet::new()
+    };
+
     let mut series: Vec<DailyMetricRow> = Vec::new();
     for ((date, chatbot_idx), acc) in &buckets {
+        if excluded_bots.contains(chatbot_idx) {
+            continue;
+        }
         if params.min_prs_per_day > 0 && acc.precision_count < params.min_prs_per_day {
             continue;
         }
@@ -410,6 +427,12 @@ pub fn leaderboard(snapshot: &Snapshot, params: &FilterParams) -> LeaderboardRes
     // Build rows for all chatbots that have at least one filtered record
     let mut rows: Vec<LeaderboardRow> = sampled_counts
         .iter()
+        .filter(|(&idx, _)| {
+            if params.min_scored_prs == 0 { return true; }
+            accums.get(&idx)
+                .map(|a| a.precision_count >= params.min_scored_prs)
+                .unwrap_or(false)
+        })
         .map(|(&idx, &sampled)| {
             let acc = accums.get(&idx);
             let (avg_p, avg_r, f_score, scored) = match acc {

--- a/online/api_service/src/handlers.rs
+++ b/online/api_service/src/handlers.rs
@@ -35,6 +35,7 @@ pub struct MetricsQuery {
     pub require_human_engagement: Option<bool>,
     pub min_human_reviewers: Option<u32>,
     pub min_commits_after_review: Option<u32>,
+    pub min_scored_prs: Option<usize>,
 }
 
 fn parse_date(s: &str) -> Option<NaiveDate> {
@@ -86,6 +87,7 @@ fn to_filter_params(q: &MetricsQuery) -> FilterParams {
         require_human_engagement: q.require_human_engagement.unwrap_or(false),
         min_human_reviewers: q.min_human_reviewers,
         min_commits_after_review: q.min_commits_after_review,
+        min_scored_prs: q.min_scored_prs.unwrap_or(0),
     }
 }
 

--- a/online/api_service/src/model.rs
+++ b/online/api_service/src/model.rs
@@ -172,6 +172,8 @@ pub struct FilterParams {
     pub min_human_reviewers: Option<u32>,
     /// Minimum commits after bot review
     pub min_commits_after_review: Option<u32>,
+    /// Hide bots with fewer than this many scored PRs in the period
+    pub min_scored_prs: usize,
 }
 
 impl Default for FilterParams {
@@ -198,6 +200,7 @@ impl Default for FilterParams {
             require_human_engagement: false,
             min_human_reviewers: None,
             min_commits_after_review: None,
+            min_scored_prs: 0,
         }
     }
 }

--- a/online/api_service/src/tests.rs
+++ b/online/api_service/src/tests.rs
@@ -840,6 +840,156 @@ mod tests {
         assert_eq!(result.records[0].1.commits_after_review, 5);
     }
 
+    // -----------------------------------------------------------------------
+    // min_scored_prs tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_min_scored_prs_hides_low_count_bot_from_leaderboard() {
+        // bot1: 5 scored PRs, bot2: 2 scored PRs
+        let snap = make_snapshot(
+            vec![("bot1", "Bot One"), ("bot2", "Bot Two")],
+            vec![],
+            vec![
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.5), Some(0.5))),
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.6), Some(0.6))),
+                (date(2026, 2, 2), rec(0, dt(2026, 2, 2), Some(0.5), Some(0.5))),
+                (date(2026, 2, 2), rec(0, dt(2026, 2, 2), Some(0.6), Some(0.6))),
+                (date(2026, 2, 3), rec(0, dt(2026, 2, 3), Some(0.7), Some(0.7))),
+                (date(2026, 2, 1), rec(1, dt(2026, 2, 1), Some(0.8), Some(0.8))),
+                (date(2026, 2, 2), rec(1, dt(2026, 2, 2), Some(0.9), Some(0.9))),
+            ],
+        );
+
+        // No filter: both bots appear
+        let resp = leaderboard(&snap, &FilterParams::default());
+        assert_eq!(resp.rows.len(), 2);
+
+        // min_scored_prs=3: bot2 (2 scored) hidden, bot1 (5 scored) remains
+        let params = FilterParams {
+            min_scored_prs: 3,
+            ..Default::default()
+        };
+        let resp = leaderboard(&snap, &params);
+        assert_eq!(resp.rows.len(), 1);
+        assert_eq!(resp.rows[0].chatbot, "bot1");
+        assert_eq!(resp.rows[0].scored_prs, 5);
+    }
+
+    #[test]
+    fn test_min_scored_prs_zero_shows_all() {
+        let snap = make_snapshot(
+            vec![("bot1", "Bot One"), ("bot2", "Bot Two")],
+            vec![],
+            vec![
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.5), Some(0.5))),
+                (date(2026, 2, 1), rec(1, dt(2026, 2, 1), Some(0.8), Some(0.8))),
+            ],
+        );
+
+        let params = FilterParams {
+            min_scored_prs: 0,
+            ..Default::default()
+        };
+        let resp = leaderboard(&snap, &params);
+        assert_eq!(resp.rows.len(), 2);
+    }
+
+    #[test]
+    fn test_min_scored_prs_counts_only_fully_scored() {
+        // bot1 has 3 records: 2 with both P+R, 1 with only P (no recall)
+        let snap = make_snapshot(
+            vec![("bot1", "Bot One")],
+            vec![],
+            vec![
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.5), Some(0.5))),
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.6), Some(0.6))),
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.7), None)),
+            ],
+        );
+
+        // min_scored_prs=3: bot1 has only 2 scored (the one without recall doesn't count)
+        let params = FilterParams {
+            min_scored_prs: 3,
+            ..Default::default()
+        };
+        let resp = leaderboard(&snap, &params);
+        assert_eq!(resp.rows.len(), 0);
+
+        // min_scored_prs=2: bot1 has exactly 2 scored → passes
+        let params = FilterParams {
+            min_scored_prs: 2,
+            ..Default::default()
+        };
+        let resp = leaderboard(&snap, &params);
+        assert_eq!(resp.rows.len(), 1);
+    }
+
+    #[test]
+    fn test_min_scored_prs_hides_bot_from_daily_metrics() {
+        // bot1: 4 scored PRs across 2 days, bot2: 1 scored PR
+        let snap = make_snapshot(
+            vec![("bot1", "Bot One"), ("bot2", "Bot Two")],
+            vec![],
+            vec![
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.5), Some(0.5))),
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.6), Some(0.6))),
+                (date(2026, 2, 2), rec(0, dt(2026, 2, 2), Some(0.7), Some(0.7))),
+                (date(2026, 2, 2), rec(0, dt(2026, 2, 2), Some(0.8), Some(0.8))),
+                (date(2026, 2, 1), rec(1, dt(2026, 2, 1), Some(0.9), Some(0.9))),
+            ],
+        );
+
+        // No filter: bot1 has 2 day entries, bot2 has 1 → 3 total
+        let resp = daily_metrics(&snap, &FilterParams::default());
+        assert_eq!(resp.series.len(), 3);
+
+        // min_scored_prs=2: bot2 (1 scored) excluded from chart
+        let params = FilterParams {
+            min_scored_prs: 2,
+            ..Default::default()
+        };
+        let resp = daily_metrics(&snap, &params);
+        assert_eq!(resp.series.len(), 2);
+        assert!(resp.series.iter().all(|r| r.chatbot == "bot1"));
+    }
+
+    #[test]
+    fn test_min_scored_prs_with_min_prs_per_day() {
+        // bot1: day1 has 3 scored, day2 has 1 scored
+        // min_prs_per_day=2 drops day2, so only day1's 3 count as scored
+        // min_scored_prs=4 should then hide bot1 since effective scored = 3
+        let snap = make_snapshot(
+            vec![("bot1", "Bot One")],
+            vec![],
+            vec![
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.5), Some(0.5))),
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.6), Some(0.6))),
+                (date(2026, 2, 1), rec(0, dt(2026, 2, 1), Some(0.7), Some(0.7))),
+                (date(2026, 2, 2), rec(0, dt(2026, 2, 2), Some(0.8), Some(0.8))),
+            ],
+        );
+
+        // min_prs_per_day=2, min_scored_prs=4: day2 dropped (1 pr), remaining scored=3 < 4
+        let params = FilterParams {
+            min_prs_per_day: 2,
+            min_scored_prs: 4,
+            ..Default::default()
+        };
+        let resp = leaderboard(&snap, &params);
+        assert_eq!(resp.rows.len(), 0);
+
+        // min_prs_per_day=2, min_scored_prs=3: day2 dropped, remaining scored=3 >= 3
+        let params = FilterParams {
+            min_prs_per_day: 2,
+            min_scored_prs: 3,
+            ..Default::default()
+        };
+        let resp = leaderboard(&snap, &params);
+        assert_eq!(resp.rows.len(), 1);
+        assert_eq!(resp.rows[0].scored_prs, 3);
+    }
+
     #[test]
     fn test_engagement_filters_combined() {
         let mut r_full = rec(0, dt(2026, 2, 1), Some(0.9), Some(0.9));

--- a/online/api_service/static/index.html
+++ b/online/api_service/static/index.html
@@ -42,9 +42,11 @@ tr:hover td{background:#f9f9f9}
   </div>
   <label>F-beta (&beta;)</label>
   <input type="number" id="beta" value="1.0" min="0.1" max="10" step="0.1">
-  <label>Min PRs (total)</label>
+  <label title="Hide bots with fewer than this many total discovered PRs in the selected period">Min PRs (volume)</label>
   <input type="number" id="min-prs-total" value="0" min="0" step="1">
-  <label>Min PRs (per day)</label>
+  <label title="Hide bots with fewer than this many scored PRs in the selected period">Min scored PRs</label>
+  <input type="number" id="min-scored-prs" value="0" min="0" step="1">
+  <label title="Exclude days where a bot has fewer than this many scored PRs from the score average">Min daily sample size</label>
   <input type="number" id="min-prs" value="0" min="0" step="1">
   <label>Diff lines range</label>
   <div class="row">
@@ -140,7 +142,7 @@ async function init(){
   $('#end-date').value=d.end;
   // Build initial color map from all chatbots
   assignColors(o.chatbots);
-  for(const id of['start-date','end-date','beta','min-prs-total','min-prs','diff-min','diff-max','exclude-self-authored','exclude-bot-authored','require-reviews','include-ignored','min-repo-contributors','max-author-repo-prs','require-human-engagement','min-human-reviewers','min-commits-after-review'])
+  for(const id of['start-date','end-date','beta','min-prs-total','min-scored-prs','min-prs','diff-min','diff-max','exclude-self-authored','exclude-bot-authored','require-reviews','include-ignored','min-repo-contributors','max-author-repo-prs','require-human-engagement','min-human-reviewers','min-commits-after-review'])
     document.getElementById(id).addEventListener('change',refresh);
   refresh();
 }
@@ -153,6 +155,8 @@ function qs(){
   p.set('beta',$('#beta').value||'1.0');
   const mpt=$('#min-prs-total').value;
   if(mpt&&mpt!=='0') p.set('min_total_prs',mpt);
+  const msp=$('#min-scored-prs').value;
+  if(msp&&msp!=='0') p.set('min_scored_prs',msp);
   const mp=$('#min-prs').value;
   if(mp&&mp!=='0') p.set('min_prs_per_day',mp);
   const dmin=$('#diff-min').value, dmax=$('#diff-max').value;


### PR DESCRIPTION
- Adds a `min_scored_prs` parameter to the API that hides bots with fewer than N scored PRs (PRs with both non-null precision and recall) in the selected period
- Applied to both the leaderboard and the daily F-score chart
- Distinct from `min_total_prs` (which uses raw discovered volume) and `min_prs_per_day` (which drops low-sample days from averages)