### PR TITLE
Update PR volume counting from GitHub Archive to GitHub Search API

### DIFF
--- a/online/etl/main.py
+++ b/online/etl/main.py
@@ -223,10 +223,18 @@ def build_parser() -> argparse.ArgumentParser:
     p_lbl.add_argument("--verbose", action="store_true")
 
     # volumes
-    p_vol = sub.add_parser("volumes", help="Fetch PR volume counts from BigQuery")
+    p_vol = sub.add_parser("volumes", help="Fetch PR volume counts from BigQuery or GitHub Search API")
     p_vol.add_argument("--chatbot", help="GitHub username of the chatbot")
     p_vol.add_argument(
         "--all", action="store_true", dest="all_chatbots", help="Fetch volumes for all registered chatbots"
+    )
+    p_vol.add_argument(
+        "--source", choices=["bq", "search-api"], default="search-api",
+        help="Data source: 'bq' for BigQuery/GH Archive (legacy), 'search-api' for GitHub Search API (default)",
+    )
+    p_vol.add_argument(
+        "--weekly", action="store_true",
+        help="(search-api only) Query in weekly chunks instead of daily. ~7x fewer API calls, less accurate per-day.",
     )
     p_vol.add_argument("--days-back", type=int, default=7)
     p_vol.add_argument("--start-date", help="YYYY-MM-DD")
@@ -571,7 +579,6 @@ async def cmd_volumes(args: argparse.Namespace) -> None:
     from db.connection import DBAdapter
     from db.repository import PRRepository
     from db.schema import create_tables
-    from pipeline.volumes import fetch_pr_volumes
 
     cfg = DBConfig(verbose=args.verbose)
     if args.database_url:
@@ -598,8 +605,18 @@ async def cmd_volumes(args: argparse.Namespace) -> None:
         else:
             usernames = [args.chatbot]
 
-        logger.info(f"Fetching PR volumes for {len(usernames)} chatbot(s): {start_date} to {end_date}")
-        count = await fetch_pr_volumes(cfg, db, usernames, start_date, end_date)
+        source = args.source
+        logger.info(f"Fetching PR volumes ({source}) for {len(usernames)} chatbot(s): {start_date} to {end_date}")
+
+        if source == "search-api":
+            from pipeline.volumes import fetch_pr_volumes_search_api
+            count = await fetch_pr_volumes_search_api(
+                cfg, db, usernames, start_date, end_date, weekly=args.weekly,
+            )
+        else:
+            from pipeline.volumes import fetch_pr_volumes
+            count = await fetch_pr_volumes(cfg, db, usernames, start_date, end_date)
+
         logger.info(f"Done: {count} volume rows upserted")
     finally:
         await db.close()

--- a/online/etl/pipeline/volumes.py
+++ b/online/etl/pipeline/volumes.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import date
+from datetime import timedelta
 import enum
 import logging
-from datetime import date, timedelta
 
 from google.cloud import bigquery
 import httpx

--- a/online/etl/pipeline/volumes.py
+++ b/online/etl/pipeline/volumes.py
@@ -21,6 +21,10 @@ logger = logging.getLogger(__name__)
 GITHUB_SEARCH_URL = "https://api.github.com/search/issues"
 # Seconds to sleep between Search API requests to avoid secondary rate limits
 SEARCH_API_SLEEP = 6
+# Bots whose GH Archive username differs from their Search API username
+SEARCH_API_USERNAME_MAP: dict[str, str] = {
+    "Copilot": "copilot-pull-request-reviewer[bot]",
+}
 
 # Count unique PRs a bot interacted with, assigned to first-seen day.
 # Each PR is counted exactly once (on the earliest day the bot touched it),
@@ -273,11 +277,12 @@ async def fetch_pr_volumes_search_api(
     ) as client:
         for username in chatbot_usernames:
             chatbot_id = username_to_id[username]
+            search_username = SEARCH_API_USERNAME_MAP.get(username, username)
             bot_skipped = False
 
             if weekly:
                 for chunk_start, chunk_end in chunks:
-                    result = await _search_api_count(client, username, chunk_start, chunk_end)
+                    result = await _search_api_count(client, search_username, chunk_start, chunk_end)
                     if result is SearchError.UNSEARCHABLE:
                         skipped_bots.append(username)
                         bot_skipped = True
@@ -301,7 +306,7 @@ async def fetch_pr_volumes_search_api(
                     await asyncio.sleep(SEARCH_API_SLEEP)
             else:
                 for day in dates:
-                    result = await _search_api_count(client, username, day)
+                    result = await _search_api_count(client, search_username, day)
                     if result is SearchError.UNSEARCHABLE:
                         skipped_bots.append(username)
                         bot_skipped = True

--- a/online/etl/pipeline/volumes.py
+++ b/online/etl/pipeline/volumes.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import asyncio
 import enum
 import logging
-import time
-from urllib.parse import quote
-
-import httpx
+from datetime import date, timedelta
 
 from google.cloud import bigquery
+import httpx
 
 from config import DBConfig
 from db.connection import DBAdapter
@@ -188,8 +186,6 @@ async def _search_api_count(
 
 def _date_range(start_date: str, end_date: str) -> list[str]:
     """Generate YYYY-MM-DD strings for each day in [start_date, end_date]."""
-    from datetime import date, timedelta
-
     start = date.fromisoformat(start_date)
     end = date.fromisoformat(end_date)
     dates: list[str] = []
@@ -206,8 +202,6 @@ def _weekly_chunks(start_date: str, end_date: str) -> list[tuple[str, str]]:
     Returns list of (chunk_start, chunk_end) pairs covering the full range.
     The last chunk may be shorter than 7 days.
     """
-    from datetime import date, timedelta
-
     start = date.fromisoformat(start_date)
     end = date.fromisoformat(end_date)
     chunks: list[tuple[str, str]] = []

--- a/online/etl/pipeline/volumes.py
+++ b/online/etl/pipeline/volumes.py
@@ -1,8 +1,13 @@
-"""Pipeline stage: Fetch PR volume counts from BigQuery and store in database."""
+"""Pipeline stage: Fetch PR volume counts from BigQuery or GitHub Search API."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
+from urllib.parse import quote
+
+import httpx
 
 from google.cloud import bigquery
 
@@ -11,6 +16,10 @@ from db.connection import DBAdapter
 from db.repository import PRRepository
 
 logger = logging.getLogger(__name__)
+
+GITHUB_SEARCH_URL = "https://api.github.com/search/issues"
+# Seconds to sleep between Search API requests to avoid secondary rate limits
+SEARCH_API_SLEEP = 6
 
 # Count unique PRs a bot interacted with, assigned to first-seen day.
 # Each PR is counted exactly once (on the earliest day the bot touched it),
@@ -114,4 +123,180 @@ async def fetch_pr_volumes(
             upserted += 1
 
     logger.info(f"Upserted {upserted} volume rows for {len(chatbot_usernames)} chatbots")
+    return upserted
+
+
+async def _search_api_count(
+    client: httpx.AsyncClient,
+    bot_username: str,
+    start_date: str,
+    end_date: str | None = None,
+) -> int | None:
+    """Query GitHub Search API for PRs reviewed by a bot in a date range.
+
+    Returns the total_count, or None if the request fails.
+    Uses `reviewed-by:<bot> type:pr created:<start>..<end>`.
+    If end_date is None, queries a single day.
+    """
+    end = end_date or start_date
+    query = f"type:pr reviewed-by:{bot_username} created:{start_date}..{end}"
+    for attempt in range(3):
+        try:
+            resp = await client.get(
+                GITHUB_SEARCH_URL,
+                params={"q": query, "per_page": "1"},
+            )
+            if resp.status_code == 422:
+                # "Validation Failed" — bot username not searchable (e.g. non-[bot] accounts)
+                logger.warning(f"Search API 422 for {bot_username} — username not searchable")
+                return None
+            if resp.status_code == 403:
+                retry_after = resp.headers.get("Retry-After")
+                wait = int(retry_after) if retry_after else 60
+                logger.warning(
+                    f"Search API rate limited for {bot_username}, "
+                    f"waiting {wait}s (attempt {attempt + 1}/3)"
+                )
+                await asyncio.sleep(wait)
+                continue
+            resp.raise_for_status()
+            return resp.json().get("total_count", 0)
+        except httpx.HTTPError as e:
+            if attempt < 2:
+                await asyncio.sleep(2 ** (attempt + 1))
+            else:
+                logger.error(f"Search API failed for {bot_username} on {start_date}..{end}: {e}")
+                return None
+    return None
+
+
+def _date_range(start_date: str, end_date: str) -> list[str]:
+    """Generate YYYY-MM-DD strings for each day in [start_date, end_date]."""
+    from datetime import date, timedelta
+
+    start = date.fromisoformat(start_date)
+    end = date.fromisoformat(end_date)
+    dates: list[str] = []
+    current = start
+    while current <= end:
+        dates.append(current.isoformat())
+        current += timedelta(days=1)
+    return dates
+
+
+def _weekly_chunks(start_date: str, end_date: str) -> list[tuple[str, str]]:
+    """Split a date range into weekly (7-day) chunks.
+
+    Returns list of (chunk_start, chunk_end) pairs covering the full range.
+    The last chunk may be shorter than 7 days.
+    """
+    from datetime import date, timedelta
+
+    start = date.fromisoformat(start_date)
+    end = date.fromisoformat(end_date)
+    chunks: list[tuple[str, str]] = []
+    current = start
+    while current <= end:
+        chunk_end = min(current + timedelta(days=6), end)
+        chunks.append((current.isoformat(), chunk_end.isoformat()))
+        current = chunk_end + timedelta(days=1)
+    return chunks
+
+
+async def fetch_pr_volumes_search_api(
+    cfg: DBConfig,
+    db: DBAdapter,
+    chatbot_usernames: list[str],
+    start_date: str,
+    end_date: str,
+    weekly: bool = False,
+) -> int:
+    """Query GitHub Search API for PR counts per bot and upsert into pr_volumes.
+
+    Uses `reviewed-by:<bot>` to count unique PRs, attributed to PR creation date.
+    Sleeps between requests to stay under secondary rate limits.
+
+    When weekly=True, queries in 7-day chunks and distributes the count evenly
+    across days. This reduces API calls by ~7x for backfills at the cost of
+    less accurate per-day granularity (totals remain exact).
+
+    Returns the number of rows upserted.
+    """
+    repo = PRRepository(db)
+
+    username_to_id: dict[str, int] = {}
+    for username in chatbot_usernames:
+        cid = await repo.upsert_chatbot(username)
+        username_to_id[username] = cid
+
+    token = cfg.github_tokens[0] if cfg.github_tokens else cfg.github_token
+    if not token:
+        logger.error("No GitHub token available for Search API volumes")
+        return 0
+
+    if weekly:
+        chunks = _weekly_chunks(start_date, end_date)
+        total_queries = len(chatbot_usernames) * len(chunks)
+        logger.info(
+            f"Fetching Search API volumes (weekly) for {len(chatbot_usernames)} bots "
+            f"x {len(chunks)} chunks = {total_queries} queries"
+        )
+    else:
+        dates = _date_range(start_date, end_date)
+        total_queries = len(chatbot_usernames) * len(dates)
+        logger.info(
+            f"Fetching Search API volumes (daily) for {len(chatbot_usernames)} bots "
+            f"x {len(dates)} days = {total_queries} queries"
+        )
+
+    upserted = 0
+    async with httpx.AsyncClient(
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        timeout=30.0,
+    ) as client:
+        for username in chatbot_usernames:
+            chatbot_id = username_to_id[username]
+
+            if weekly:
+                for chunk_start, chunk_end in chunks:
+                    count = await _search_api_count(client, username, chunk_start, chunk_end)
+                    if count is None:
+                        logger.debug(f"Skipping {username} for {chunk_start}..{chunk_end} (no result)")
+                        await asyncio.sleep(SEARCH_API_SLEEP)
+                        continue
+
+                    chunk_days = _date_range(chunk_start, chunk_end)
+                    num_days = len(chunk_days)
+                    # Distribute evenly; put remainder on the last day
+                    base = count // num_days
+                    remainder = count % num_days
+
+                    async with db.transaction():
+                        for i, day in enumerate(chunk_days):
+                            day_count = base + (1 if i >= num_days - remainder else 0)
+                            await repo.upsert_pr_volume(chatbot_id, day, day_count)
+                            upserted += 1
+
+                    await asyncio.sleep(SEARCH_API_SLEEP)
+            else:
+                for day in dates:
+                    count = await _search_api_count(client, username, day)
+                    if count is None:
+                        logger.debug(f"Skipping {username} on {day} (no result)")
+                        await asyncio.sleep(SEARCH_API_SLEEP)
+                        continue
+
+                    async with db.transaction():
+                        await repo.upsert_pr_volume(chatbot_id, day, count)
+                    upserted += 1
+
+                    await asyncio.sleep(SEARCH_API_SLEEP)
+
+            logger.info(f"  {username}: upserted so far: {upserted}")
+
+    logger.info(f"Search API volumes: upserted {upserted} rows for {len(chatbot_usernames)} bots")
     return upserted

--- a/online/etl/pipeline/volumes.py
+++ b/online/etl/pipeline/volumes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import enum
 import logging
 import time
 from urllib.parse import quote
@@ -126,20 +127,30 @@ async def fetch_pr_volumes(
     return upserted
 
 
+class SearchError(enum.Enum):
+    """Non-count outcomes from _search_api_count."""
+    UNSEARCHABLE = "unsearchable"  # 422: username not recognized by Search API
+    TRANSIENT = "transient"        # request failed after retries
+
+
+SearchResult = int | SearchError
+
+
 async def _search_api_count(
     client: httpx.AsyncClient,
     bot_username: str,
     start_date: str,
     end_date: str | None = None,
-) -> int | None:
-    """Query GitHub Search API for PRs reviewed by a bot in a date range.
+    qualifier: str = "reviewed-by",
+) -> SearchResult:
+    """Query GitHub Search API for PRs involving a bot in a date range.
 
-    Returns the total_count, or None if the request fails.
-    Uses `reviewed-by:<bot> type:pr created:<start>..<end>`.
+    Returns the total_count on success, or a SearchError variant on failure.
+    Uses `<qualifier>:<bot> type:pr created:<start>..<end>`.
     If end_date is None, queries a single day.
     """
     end = end_date or start_date
-    query = f"type:pr reviewed-by:{bot_username} created:{start_date}..{end}"
+    query = f"type:pr {qualifier}:{bot_username} created:{start_date}..{end}"
     for attempt in range(3):
         try:
             resp = await client.get(
@@ -147,9 +158,10 @@ async def _search_api_count(
                 params={"q": query, "per_page": "1"},
             )
             if resp.status_code == 422:
-                # "Validation Failed" — bot username not searchable (e.g. non-[bot] accounts)
-                logger.warning(f"Search API 422 for {bot_username} — username not searchable")
-                return None
+                logger.warning(
+                    f"Search API 422 for {bot_username} ({qualifier}:) — username not searchable"
+                )
+                return SearchError.UNSEARCHABLE
             if resp.status_code == 403:
                 retry_after = resp.headers.get("Retry-After")
                 wait = int(retry_after) if retry_after else 60
@@ -166,8 +178,8 @@ async def _search_api_count(
                 await asyncio.sleep(2 ** (attempt + 1))
             else:
                 logger.error(f"Search API failed for {bot_username} on {start_date}..{end}: {e}")
-                return None
-    return None
+                return SearchError.TRANSIENT
+    return SearchError.TRANSIENT
 
 
 def _date_range(start_date: str, end_date: str) -> list[str]:
@@ -250,6 +262,7 @@ async def fetch_pr_volumes_search_api(
         )
 
     upserted = 0
+    skipped_bots: list[str] = []
     async with httpx.AsyncClient(
         headers={
             "Authorization": f"Bearer {token}",
@@ -260,20 +273,24 @@ async def fetch_pr_volumes_search_api(
     ) as client:
         for username in chatbot_usernames:
             chatbot_id = username_to_id[username]
+            bot_skipped = False
 
             if weekly:
                 for chunk_start, chunk_end in chunks:
-                    count = await _search_api_count(client, username, chunk_start, chunk_end)
-                    if count is None:
-                        logger.debug(f"Skipping {username} for {chunk_start}..{chunk_end} (no result)")
+                    result = await _search_api_count(client, username, chunk_start, chunk_end)
+                    if result is SearchError.UNSEARCHABLE:
+                        skipped_bots.append(username)
+                        bot_skipped = True
+                        break
+                    if isinstance(result, SearchError):
                         await asyncio.sleep(SEARCH_API_SLEEP)
                         continue
+                    assert isinstance(result, int)
 
                     chunk_days = _date_range(chunk_start, chunk_end)
                     num_days = len(chunk_days)
-                    # Distribute evenly; put remainder on the last day
-                    base = count // num_days
-                    remainder = count % num_days
+                    base = result // num_days
+                    remainder = result % num_days
 
                     async with db.transaction():
                         for i, day in enumerate(chunk_days):
@@ -284,19 +301,32 @@ async def fetch_pr_volumes_search_api(
                     await asyncio.sleep(SEARCH_API_SLEEP)
             else:
                 for day in dates:
-                    count = await _search_api_count(client, username, day)
-                    if count is None:
-                        logger.debug(f"Skipping {username} on {day} (no result)")
+                    result = await _search_api_count(client, username, day)
+                    if result is SearchError.UNSEARCHABLE:
+                        skipped_bots.append(username)
+                        bot_skipped = True
+                        break
+                    if isinstance(result, SearchError):
                         await asyncio.sleep(SEARCH_API_SLEEP)
                         continue
+                    assert isinstance(result, int)
 
                     async with db.transaction():
-                        await repo.upsert_pr_volume(chatbot_id, day, count)
+                        await repo.upsert_pr_volume(chatbot_id, day, result)
                     upserted += 1
 
                     await asyncio.sleep(SEARCH_API_SLEEP)
 
-            logger.info(f"  {username}: upserted so far: {upserted}")
+            if bot_skipped:
+                logger.info(f"  {username}: skipped (unsearchable)")
+            else:
+                logger.info(f"  {username}: upserted so far: {upserted}")
+
+    if skipped_bots:
+        logger.warning(
+            f"Skipped {len(skipped_bots)} unsearchable bot(s) (use --source bq for these): "
+            f"{', '.join(skipped_bots)}"
+        )
 
     logger.info(f"Search API volumes: upserted {upserted} rows for {len(chatbot_usernames)} bots")
     return upserted

--- a/online/etl/tests/test_volumes.py
+++ b/online/etl/tests/test_volumes.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
+from datetime import date, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
-from hypothesis import given
-from hypothesis import settings
+from hypothesis import given, settings
 from hypothesis import strategies as st
 import httpx
 import pytest
@@ -97,8 +96,6 @@ def test_date_range_empty_when_start_after_end() -> None:
 )
 @settings(max_examples=100)
 def test_date_range_length(year: int, month: int, day: int, span: int) -> None:
-    from datetime import date, timedelta
-
     start = date(year, month, day)
     end = start + timedelta(days=span)
     result = _date_range(start.isoformat(), end.isoformat())

--- a/online/etl/tests/test_volumes.py
+++ b/online/etl/tests/test_volumes.py
@@ -1,14 +1,21 @@
-"""Tests for volumes.py utility functions: date/suffix conversion."""
+"""Tests for volumes.py utility functions: date/suffix conversion and Search API volumes."""
 
 from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
+import httpx
 import pytest
 
+from pipeline.volumes import _date_range
 from pipeline.volumes import _date_to_suffix
+from pipeline.volumes import _search_api_count
 from pipeline.volumes import _suffix_to_date
+from pipeline.volumes import _weekly_chunks
 
 # -- _date_to_suffix ----------------------------------------------------------
 
@@ -63,3 +70,126 @@ def test_suffix_always_6_digits(year: int, month: int, day: int) -> None:
     suffix = _date_to_suffix(date_str)
     assert len(suffix) == 6
     assert suffix.isdigit()
+
+
+# -- _date_range ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("start,end,expected", [
+    ("2026-06-15", "2026-06-15", ["2026-06-15"]),
+    ("2026-06-15", "2026-06-17", ["2026-06-15", "2026-06-16", "2026-06-17"]),
+    ("2026-12-30", "2027-01-02", ["2026-12-30", "2026-12-31", "2027-01-01", "2027-01-02"]),
+])
+def test_date_range(start: str, end: str, expected: list[str]) -> None:
+    assert _date_range(start, end) == expected
+
+
+def test_date_range_empty_when_start_after_end() -> None:
+    assert _date_range("2026-06-17", "2026-06-15") == []
+
+
+@given(
+    year=st.integers(min_value=2020, max_value=2030),
+    month=st.integers(min_value=1, max_value=12),
+    day=st.integers(min_value=1, max_value=28),
+    span=st.integers(min_value=0, max_value=60),
+)
+@settings(max_examples=100)
+def test_date_range_length(year: int, month: int, day: int, span: int) -> None:
+    from datetime import date, timedelta
+
+    start = date(year, month, day)
+    end = start + timedelta(days=span)
+    result = _date_range(start.isoformat(), end.isoformat())
+    assert len(result) == span + 1
+
+
+# -- _search_api_count ---------------------------------------------------------
+
+
+# -- _weekly_chunks ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("start,end,expected", [
+    ("2026-06-01", "2026-06-07", [("2026-06-01", "2026-06-07")]),
+    ("2026-06-01", "2026-06-14", [("2026-06-01", "2026-06-07"), ("2026-06-08", "2026-06-14")]),
+    ("2026-06-01", "2026-06-10", [("2026-06-01", "2026-06-07"), ("2026-06-08", "2026-06-10")]),
+    ("2026-06-15", "2026-06-15", [("2026-06-15", "2026-06-15")]),
+])
+def test_weekly_chunks(start: str, end: str, expected: list[tuple[str, str]]) -> None:
+    assert _weekly_chunks(start, end) == expected
+
+
+def test_weekly_chunks_cover_full_range() -> None:
+    """Every day in the range should appear in exactly one chunk."""
+    chunks = _weekly_chunks("2026-01-01", "2026-03-15")
+    all_days: list[str] = []
+    for chunk_start, chunk_end in chunks:
+        all_days.extend(_date_range(chunk_start, chunk_end))
+    expected = _date_range("2026-01-01", "2026-03-15")
+    assert all_days == expected
+
+
+# -- _search_api_count ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_api_count_single_day() -> None:
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"total_count": 1515}
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = mock_response
+
+    result = await _search_api_count(mock_client, "greptile-apps[bot]", "2026-06-15")
+    assert result == 1515
+
+    call_args = mock_client.get.call_args
+    assert call_args[1]["params"]["q"] == "type:pr reviewed-by:greptile-apps[bot] created:2026-06-15..2026-06-15"
+
+
+@pytest.mark.asyncio
+async def test_search_api_count_date_range() -> None:
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"total_count": 5000}
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = mock_response
+
+    result = await _search_api_count(mock_client, "coderabbitai[bot]", "2026-06-01", "2026-06-07")
+    assert result == 5000
+
+    call_args = mock_client.get.call_args
+    assert call_args[1]["params"]["q"] == "type:pr reviewed-by:coderabbitai[bot] created:2026-06-01..2026-06-07"
+
+
+@pytest.mark.asyncio
+async def test_search_api_count_422_returns_none() -> None:
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 422
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = mock_response
+
+    result = await _search_api_count(mock_client, "Copilot", "2026-06-15")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_search_api_count_retries_on_rate_limit() -> None:
+    rate_limited = MagicMock(spec=httpx.Response)
+    rate_limited.status_code = 403
+    rate_limited.headers = {"Retry-After": "1"}
+
+    success = MagicMock(spec=httpx.Response)
+    success.status_code = 200
+    success.json.return_value = {"total_count": 42}
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.side_effect = [rate_limited, success]
+
+    result = await _search_api_count(mock_client, "test[bot]", "2026-06-15")
+    assert result == 42
+    assert mock_client.get.call_count == 2

--- a/online/etl/tests/test_volumes.py
+++ b/online/etl/tests/test_volumes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from hypothesis import given
 from hypothesis import settings

--- a/online/etl/tests/test_volumes.py
+++ b/online/etl/tests/test_volumes.py
@@ -179,10 +179,13 @@ async def test_search_api_count_422_returns_unsearchable() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_api_count_retries_on_rate_limit() -> None:
+async def test_search_api_count_retries_on_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_sleep = AsyncMock()
+    monkeypatch.setattr("pipeline.volumes.asyncio.sleep", mock_sleep)
+
     rate_limited = MagicMock(spec=httpx.Response)
     rate_limited.status_code = 403
-    rate_limited.headers = {"Retry-After": "1"}
+    rate_limited.headers = {"Retry-After": "60"}
 
     success = MagicMock(spec=httpx.Response)
     success.status_code = 200
@@ -194,3 +197,4 @@ async def test_search_api_count_retries_on_rate_limit() -> None:
     result = await _search_api_count(mock_client, "test[bot]", "2026-06-15")
     assert result == 42
     assert mock_client.get.call_count == 2
+    mock_sleep.assert_awaited_once_with(60)

--- a/online/etl/tests/test_volumes.py
+++ b/online/etl/tests/test_volumes.py
@@ -11,6 +11,7 @@ from hypothesis import strategies as st
 import httpx
 import pytest
 
+from pipeline.volumes import SearchError
 from pipeline.volumes import _date_range
 from pipeline.volumes import _date_to_suffix
 from pipeline.volumes import _search_api_count
@@ -166,7 +167,7 @@ async def test_search_api_count_date_range() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_api_count_422_returns_none() -> None:
+async def test_search_api_count_422_returns_unsearchable() -> None:
     mock_response = MagicMock(spec=httpx.Response)
     mock_response.status_code = 422
 
@@ -174,7 +175,7 @@ async def test_search_api_count_422_returns_none() -> None:
     mock_client.get.return_value = mock_response
 
     result = await _search_api_count(mock_client, "Copilot", "2026-06-15")
-    assert result is None
+    assert result is SearchError.UNSEARCHABLE
 
 
 @pytest.mark.asyncio

--- a/online/etl/tests/test_volumes.py
+++ b/online/etl/tests/test_volumes.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import date, timedelta
-from unittest.mock import AsyncMock, MagicMock
+from datetime import date
+from datetime import timedelta
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
-from hypothesis import given, settings
-from hypothesis import strategies as st
 import httpx
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
 import pytest
 
 from pipeline.volumes import SearchError


### PR DESCRIPTION
GitHub Archive (which mirrors the public Events API) structurally undercounts GitHub App review activity. Comparing a 2-week window (Jun 3–17), GH Archive captured only ~8–25% of actual PR review volume depending on the bot. 

This PR adds a `--source search-api` option (now the default) to the `volumes` command, using `reviewed-by:<bot> type:pr` queries. 