### PR TITLE
restrict status reset of new actions in pr timelines to non merged prs

### DIFF
--- a/online/etl/db/repository.py
+++ b/online/etl/db/repository.py
@@ -113,8 +113,9 @@ class PRRepository:
                     )
                 )
                 # New events arrived — reset to pending so PR gets
-                # re-enriched/assembled/analyzed with the updated timeline
-                if len(merged_events) > len(old_events):
+                # re-enriched/assembled/analyzed with the updated timeline.
+                # Skip reset for PRs already analyzed/labeled: post-merge events
+                if len(merged_events) > len(old_events) and existing.get("status") not in ("analyzed", "labeled"):
                     await self.db.execute(
                         *self.db._translate_params(
                             "UPDATE prs SET status = 'pending', enrichment_step = NULL, "

--- a/online/etl/db/repository.py
+++ b/online/etl/db/repository.py
@@ -327,7 +327,7 @@ class PRRepository:
         if sort_by == "sweep":
             if chatbot_id is not None:
                 return await self.db.fetchall(
-                    q.GET_ANALYZED_NOT_LABELED_SWEEP, (chatbot_id, limit)
+                    q.GET_ANALYZED_NOT_LABELED_BY_ASSEMBLED, (chatbot_id, limit)
                 )
             return await self.db.fetchall(
                 q.GET_ALL_ANALYZED_NOT_LABELED_SWEEP, (limit,)


### PR DESCRIPTION
currently, when we discover new events/actions within a PR, we reset the status to re-enrich and analyze the PR score. changing this to only when PR hasn't been merged yet. note that we only analyze PRs after merge.