### PR TITLE
Add a version for the golden set

### DIFF
--- a/offline/analysis/benchmark_dashboard.py
+++ b/offline/analysis/benchmark_dashboard.py
@@ -13,6 +13,13 @@ This script creates one dashboard HTML file with all models' data embedded:
 import json
 from pathlib import Path
 
+try:
+    from analysis.golden_version import golden_set_version
+    from analysis.golden_version import resolve_golden_dir
+except ImportError:  # running as a script: python analysis/benchmark_dashboard.py
+    from golden_version import golden_set_version
+    from golden_version import resolve_golden_dir
+
 # Tools excluded from the dashboard (superseded versions, incomplete runs, etc.)
 # Anything matching these exact slugs or the "mra-" prefix is hidden.
 _HIDDEN_TOOLS: frozenset[str] = frozenset({
@@ -1797,13 +1804,19 @@ def generate_html(all_models_data: dict, default_model: str) -> str:
     return html
 
 
-def generate_json_data(all_models_data: dict, default_model: str) -> dict:
-    """Generate JSON data structure for export."""
+def generate_json_data(all_models_data: dict, default_model: str, golden_set: dict | None = None) -> dict:
+    """Generate JSON data structure for export.
+
+    golden_set identifies the golden comment set these scores were measured
+    against; see analysis/golden_version.py. It is null when no golden files
+    were found, so the export never implies an identity it doesn't have.
+    """
     # Generate and enrich predefined filters
     predefined_filters = generate_predefined_filters(all_models_data)
     predefined_filters = enrich_predefined_filters(predefined_filters, all_models_data)
 
     return {
+        "golden_set": golden_set,
         "models": all_models_data,
         "predefined_filters": predefined_filters,
         "tool_display_names": TOOL_DISPLAY_NAMES,
@@ -1844,6 +1857,14 @@ def main():
         print(f"No model results found in {args.results_dir}")
         return
 
+    # Identify the golden set these scores are measured against
+    golden_dir = resolve_golden_dir(args.results_dir)
+    golden_set = golden_set_version(golden_dir)
+    if golden_set:
+        print(f"Golden set: {golden_set['short']} ({golden_set['comments']} comments)")
+    else:
+        print(f"Golden set: not identified (no golden comment files in {golden_dir})")
+
     # Use the model with the most tools evaluated as default
     default_model = max(all_models_data.keys(), key=lambda m: len(all_models_data[m].get("tools", [])))
 
@@ -1858,7 +1879,7 @@ def main():
 
     # Generate JSON
     print("Generating JSON data...")
-    json_data = generate_json_data(all_models_data, default_model)
+    json_data = generate_json_data(all_models_data, default_model, golden_set)
 
     with open(args.json_output, "w") as f:
         json.dump(json_data, f, indent=2)

--- a/offline/analysis/golden_version.py
+++ b/offline/analysis/golden_version.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Derive a content identifier for the golden comment set.
+
+Every score is measured against the golden set, and the golden set changes.
+Two scores are comparable only if both were measured against the same one, so
+this derives an identifier from the golden files themselves rather than from a
+number someone has to remember to bump.
+
+The identifier is a SHA-256 over every golden_comments/*.json, in sorted
+filename order. Each file contributes its name and its JSON re-serialized
+canonically (sorted keys, compact separators), so reformatting a file leaves
+the identifier alone, while editing a comment, category, severity, title or
+URL changes it. Files are read as UTF-8 explicitly, so the identifier does
+not depend on the platform's locale.
+
+Usage:
+    python -m analysis.golden_version
+    python -m analysis.golden_version --results-dir results
+"""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+SHORT_LENGTH = 12
+
+
+def resolve_golden_dir(results_dir: Path) -> Path:
+    """Locate golden_comments/ the same way the scorers do."""
+    golden_dir = results_dir.parent / "golden_comments"
+    if not golden_dir.exists():
+        golden_dir = Path("golden_comments")
+    return golden_dir
+
+
+def golden_set_version(golden_dir: Path) -> dict | None:
+    """Identify the golden set in golden_dir, or None if there isn't one.
+
+    Returns the digest plus the counts a human can check at a glance: how many
+    files, how many PRs, how many golden comments.
+    """
+    if not golden_dir.exists():
+        return None
+
+    paths = sorted(golden_dir.glob("*.json"))
+    if not paths:
+        return None
+
+    digest = hashlib.sha256()
+    prs = 0
+    comments = 0
+
+    for path in paths:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        canonical = json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        digest.update(f"{path.name}\0{canonical}\0".encode())
+
+        entries = data if isinstance(data, list) else []
+        prs += len(entries)
+        comments += sum(len(entry.get("comments", [])) for entry in entries)
+
+    sha256 = digest.hexdigest()
+    return {
+        "sha256": sha256,
+        "short": sha256[:SHORT_LENGTH],
+        "files": len(paths),
+        "prs": prs,
+        "comments": comments,
+    }
+
+
+def main() -> None:
+    """Print the identifier of the golden set that scoring would use."""
+    parser = argparse.ArgumentParser(description="Print the content identifier of the golden comment set")
+    parser.add_argument("--results-dir", type=Path, default=Path("results"))
+    args = parser.parse_args()
+
+    golden_dir = resolve_golden_dir(args.results_dir)
+    version = golden_set_version(golden_dir)
+
+    if version is None:
+        print(f"No golden comment files found in {golden_dir}")
+        return
+
+    print(f"Golden set:  {golden_dir}")
+    print(f"  version:   {version['short']}  ({version['sha256']})")
+    print(f"  contents:  {version['files']} files, {version['prs']} PRs, {version['comments']} comments")
+
+
+if __name__ == "__main__":
+    main()

--- a/offline/analysis/score_profiles.py
+++ b/offline/analysis/score_profiles.py
@@ -16,6 +16,13 @@ import argparse
 import json
 from pathlib import Path
 
+try:
+    from analysis.golden_version import golden_set_version
+    from analysis.golden_version import resolve_golden_dir
+except ImportError:  # running as a script: python analysis/score_profiles.py
+    from golden_version import golden_set_version
+    from golden_version import resolve_golden_dir
+
 PROFILE_CATEGORIES: dict[str, frozenset[str]] = {
     "strict": frozenset({"bug", "security", "concurrency", "data", "api"}),
     "core": frozenset({"bug", "security", "concurrency", "data", "api", "perf", "test_gap", "doc_defect"}),
@@ -188,6 +195,13 @@ def main() -> None:
 
     golden_categories = _load_golden_categories(args.results_dir)
     print(f"Golden categories loaded: {len(golden_categories)}")
+
+    golden_dir = resolve_golden_dir(args.results_dir)
+    golden_set = golden_set_version(golden_dir)
+    if golden_set:
+        print(f"Golden set: {golden_set['short']} ({golden_set['comments']} comments)")
+    else:
+        print(f"Golden set: not identified (no golden comment files in {golden_dir})")
 
     if args.all_profiles:
         for profile in PROFILE_CATEGORIES:

--- a/offline/tests/test_golden_version.py
+++ b/offline/tests/test_golden_version.py
@@ -1,0 +1,85 @@
+"""Tests for analysis.golden_version module."""
+
+from __future__ import annotations
+
+import json
+
+from analysis.golden_version import golden_set_version
+
+ENTRY = {
+    "url": "https://github.com/org/repo/pull/1",
+    "pr_title": "Fix the thing",
+    "comments": [
+        {"comment": "Off by one", "category": "bug", "severity": "High"},
+        {"comment": "Races on close", "category": "concurrency", "severity": "Medium"},
+    ],
+}
+
+
+def _write(golden_dir, name, entries, **dump_kwargs):
+    path = golden_dir / name
+    path.write_text(json.dumps(entries, **dump_kwargs))
+    return path
+
+
+def test_version_is_stable_across_calls(tmp_path):
+    _write(tmp_path, "a.json", [ENTRY])
+
+    first = golden_set_version(tmp_path)
+    second = golden_set_version(tmp_path)
+
+    assert first == second
+    assert len(first["sha256"]) == 64
+    assert first["short"] == first["sha256"][:12]
+
+
+def test_reformatting_does_not_change_version(tmp_path):
+    _write(tmp_path, "a.json", [ENTRY])
+    compact = golden_set_version(tmp_path)
+
+    _write(tmp_path, "a.json", [ENTRY], indent=4, sort_keys=True)
+    reformatted = golden_set_version(tmp_path)
+
+    assert compact["sha256"] == reformatted["sha256"]
+
+
+def test_editing_a_comment_changes_version(tmp_path):
+    _write(tmp_path, "a.json", [ENTRY])
+    before = golden_set_version(tmp_path)
+
+    edited = json.loads(json.dumps(ENTRY))
+    edited["comments"][0]["category"] = "security"
+    _write(tmp_path, "a.json", [edited])
+    after = golden_set_version(tmp_path)
+
+    assert before["sha256"] != after["sha256"]
+
+
+def test_adding_a_comment_changes_version_and_counts(tmp_path):
+    _write(tmp_path, "a.json", [ENTRY])
+    before = golden_set_version(tmp_path)
+
+    extended = json.loads(json.dumps(ENTRY))
+    extended["comments"].append({"comment": "Leaks a handle", "category": "bug", "severity": "Low"})
+    _write(tmp_path, "a.json", [extended])
+    after = golden_set_version(tmp_path)
+
+    assert before["sha256"] != after["sha256"]
+    assert before["comments"] == 2
+    assert after["comments"] == 3
+
+
+def test_counts_cover_every_file(tmp_path):
+    _write(tmp_path, "a.json", [ENTRY, ENTRY])
+    _write(tmp_path, "b.json", [ENTRY])
+
+    version = golden_set_version(tmp_path)
+
+    assert version["files"] == 2
+    assert version["prs"] == 3
+    assert version["comments"] == 6
+
+
+def test_returns_none_when_there_is_no_golden_set(tmp_path):
+    assert golden_set_version(tmp_path / "missing") is None
+    assert golden_set_version(tmp_path) is None


### PR DESCRIPTION
This adds a version for the golden set, derived from the golden files themselves and recorded with every scoring run. It is the version marker I offered in #50.

**Why**

The golden set changes, and nothing records which version a score was measured against.

On 6 August, PR #49 took the golden set from 137 comments to 173. That looks like a straightforward improvement, and I think it is one.

But it means a score published on 5 August and a score published on 7 August were measured against different data. Nothing in either result says so. Both are just "the benchmark".

So if you compare two numbers, or check a number quoted somewhere else against the current dashboard, you have no way to tell whether you are looking at the same measuring stick.

This gets worse over time rather than better, because the golden set should keep improving. As things stand, every improvement to it quietly invalidates comparisons with earlier numbers, and leaves no trace that it did.

**How it works**

The version is a SHA-256 over `golden_comments/*.json`, taken in sorted filename order, with each file's JSON re-serialized canonically before hashing. It is computed at scoring time and written into `benchmark_dashboard.json` under a `golden_set` key. Both `analysis` entry points print it when they run.

Because it is derived rather than declared, it cannot drift out of sync with the data:

* editing a comment, category, severity, PR title or URL changes it
* adding or removing a golden comment changes it
* reformatting or re-indenting a file does not

It also carries the counts, so `5 files, 50 PRs, 173 comments` is readable without decoding the hash.

To print it on its own:

    python -m analysis.golden_version

**What this is not**

There is no numbering scheme, no semver, no tag convention, and no policy about when to bump anything. The set identifies itself, so there is nothing to remember to do.

Deciding what a version *ought* to cover is a separate and larger question. Golden set only? Golden set plus judge model plus tool-run set? That is a design call, it is yours to make, and I did not want to make it inside a fix for the smaller problem.

I also left the HTML dashboard alone. Where a version belongs on screen is a design question rather than a correctness one.

**What it does not fix**

Scores published before this lands still do not name their golden set, and nothing can establish that now. This makes the identity visible going forward. It does not recover it backwards.

**No published number changes**

I ran the dashboard generator and `score_profiles` across all three judge directories and all three profiles, before and after.

The only difference in `benchmark_dashboard.json` is the added `golden_set` key. Every other value is identical. The only difference in CLI output is one line naming the version.

Tests cover the three properties above:

* the version is stable across runs
* reformatting a file does not change it
* editing content does change it
