### PR TITLE
Add Corbulo results

### DIFF
--- a/offline/README.md
+++ b/offline/README.md
@@ -11,6 +11,7 @@ Open replication of the code review benchmark used by companies like [Augment](h
 | [Claude Code](https://claude.ai) | AI assistant |
 | [CodeAnt](https://www.codeant.ai/) | AI code review |
 | [CodeRabbit](https://www.coderabbit.ai/) | AI code review |
+| [Corbulo](https://corbulo.dev/) | AI code review |
 | [Cursor Bugbot](https://cursor.com) | AI code review |
 | [Cubic](https://cubic.dev/) | AI code review |
 | [Devin](https://devin.ai/) | AI assistant |


### PR DESCRIPTION
Adds **Corbulo** to the offline benchmark.

Corbulo is an AI code review tool. Per `offline/README.md`, adding a tool requires forking the benchmark PRs and collecting the tool's reviews — this PR contains those reviews (steps 0 and 1). No judged outputs are included, so the results can be produced with whichever judge you prefer.

### What's here

- 50 review entries in `offline/results/benchmark_data.json` — **251 comments** (201 inline, 50 review bodies)
- One row in the evaluated-tools table

### How the reviews were produced

The 50 benchmark PRs were forked with `step0_fork_prs` into [`corbulo-martian-benchmark`](https://github.com/corbulo-martian-benchmark), where the Corbulo GitHub App is installed. Each PR carries exactly one review, posted by `corbulo-core[bot]`. Everything is public and can be inspected or re-collected with `step1_download_prs --org corbulo-martian-benchmark`.

### Consistency

Each PR's entry matches its GitHub PR exactly — verified per PR, not just in aggregate: 201 inline comments and 50 review bodies on GitHub, the same 201 and 50 in this file, zero per-PR mismatches. No PR has an empty review.

The diff is purely additive. The only removed line is the file's closing brace; no other tool's data, and no golden comment, is modified.

### Note on how the review is shaped

Blocking findings are posted as inline comments on the diff. Findings that can't be anchored to a diff line are carried in the review body, along with a summary table of everything in the review — so a reader sees the full set in one place. Since the same finding can appear both inline and in that table, the dedup pass in step 2.5 is what keeps it from counting twice.

Website: https://corbulo.dev/
