### PR TITLE
Add Shipwright results

### DIFF
--- a/offline/README.md
+++ b/offline/README.md
@@ -24,6 +24,7 @@ Open replication of the code review benchmark used by companies like [Augment](h
 | [Kodus](https://kodus.io/) | AI code review |
 | [Macroscope](https://www.macroscope.com/) | AI code review |
 | [Qodo](https://www.qodo.ai/) | AI code review |
+| [Shipwright](https://github.com/kpuru88/shipwright-agent) | AI code review agent |
 | [Sourcery](https://sourcery.ai/) | AI code review |
 
 Adding a new tool requires forking the benchmark PRs and collecting the tool's reviews — see Steps 0 and 1 below.


### PR DESCRIPTION
Adds **Shipwright** to the 50-PR offline benchmark for Martian's independent judging and ranking.

## What's included

- one `shipwright` review entry for each of the 50 benchmark tasks
- 142 findings copied directly from Shipwright `review.json` outputs
- one task with an empty finding set, preserved as produced
- one evaluated-tools row in `offline/README.md`

No judged outputs, TP/FP/FN labels, dedup groups, or golden-derived data are added. Existing tool data and golden comments are unchanged.

## How the reviews were produced

The reviews were run on Modal through Shipwright's production review-agent path:

- reviewer backend: Claude Agent SDK
- reviewer model: Sonnet
- tools: none
- execution mode: `full-review-json`
- diff context limit: 100,000 characters
- snippet context limit: 0
- findings cap: 8 per PR
- prompt SHA-256: `4701de31de6b87b020429f35406426bf7ee72898a06717005de341c40c423433`
- run ID: `staged-gepa-round2b-20260822T185655Z`

Every submitted review maps to exactly one benchmark task. Candidate text, path, and line are the official candidate conversion of that task's `review.json` findings. The prompt was generic and passed the harness's benchmark-leak checks.

Shipwright is an offline review agent rather than a GitHub App, so `pr_url` records the public source task reviewed and `repo_name` records the Shipwright run identity.

Implementation and provenance work is reviewed in https://github.com/kpuru88/shipwright-agent/pull/20.

## Preliminary result—not the requested official score

Our separate Martian/Kimi run over the 173-finding `all` profile produced TP=83, FP=60, FN=90, errors=0. That is included here only for provenance; it is not submitted as an official benchmark score. Please run Martian's normal dedup/judge pipeline and rank this submission with the public benchmark configuration.

## Validation

- exactly 50 Shipwright review entries
- exactly 50 unique task URLs
- 142 submitted findings
- upstream offline tests: 28 passed
- additive data diff only
